### PR TITLE
Add posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# Instagram story stalker
+# Instagram story & posts stalker
 
-Instagram story stalker is a tool which notifies you with a message on telegram whenever someone of your contacts adds a story.
+Instagram story & posts stalker is a tool which notifies you with a message on telegram whenever someone of your contacts adds a story or post.
+This extends the original repo with the ability to track posts as well.
 ### But why?
 Mmh, I don't know. Fun, maybe?
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,10 @@ $ python3 main.py
 
 ## How does it work?
 Actually there isn't a full control with telegram. It will be improved.
-You can add pages after confirming login by:
+You can add pages in `main.py` manually:
 ```python
-obj = Stalker(account)
-# obj.addPage("pageName")
-obj.loadAllPages()
-obj.startStalking()
+obj.addPage("pageName1")
+obj.addPage("pageName2")
 ```
 You only need to add each page to stalk manually once.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Instagram story & posts stalker
 
 Instagram story & posts stalker is a tool which notifies you with a message on telegram whenever someone of your contacts adds a story or post.
-This extends the original repo with the ability to track posts as well.
 ### But why?
 Mmh, I don't know. Fun, maybe?
 
@@ -12,6 +11,8 @@ The config.json file has the following syntax:
 {
     "token": "608599861:AAHrLZVOXeKr48k5qSPN9N-ChXy3Fhr2-KQ",
     "adminId": "48968121",
+    "onlyPosts": false,
+    "onlyStories": false,
     "instance": {
         "username": "",
         "password": ""

--- a/Stalker.py
+++ b/Stalker.py
@@ -14,7 +14,6 @@ logging.basicConfig(
     )
 logger = logging.getLogger('STALKER')
 
-
 db = Database('stories')
 
 def extractStoryData(story):
@@ -75,9 +74,11 @@ class Stalker(object):
         self.deadPages = []
         self.istance = istance
         pass
+
     def getStory(self, userid):
         self.istance.SendRequest('feed/user/' + str(userid) + '/reel_media/')
         return self.istance.LastJson
+
     def getPost(self, userid):
         self.istance.getUserFeed(userid)
         return self.istance.LastJson
@@ -119,6 +120,7 @@ class Stalker(object):
         else:
             logger.error('There was an error, {} was not in alivePages. It is a bug'.format(pageName))
         return success('Page {} removed'.format(pageName))
+
     def startStalking(self):
         while True:
             if len(self.pendingPages) == 0:

--- a/Stalker.py
+++ b/Stalker.py
@@ -154,7 +154,7 @@ class Stalker(object):
                         else:
                             notify(parseStory(d, pageName), page['referenceId'])
                         db.append('pages','page',pageName,'stories', d)
-            timeToSleep = 5
+            timeToSleep = 20
             logger.debug('[page:{}] Waiting {} seconds'.format(pageName, timeToSleep))
             time.sleep(timeToSleep)
 
@@ -186,6 +186,6 @@ class Stalker(object):
                         else:
                             notify(parsePost(d, pageName), page['referenceId'])
                         db.append('pages','page',pageName,'posts', d)
-            timeToSleep = 5
+            timeToSleep = 20
             logger.debug('[page:{}] Waiting {} seconds'.format(pageName, timeToSleep))
             time.sleep(timeToSleep)

--- a/Stalker.py
+++ b/Stalker.py
@@ -124,8 +124,16 @@ class Stalker(object):
             if len(self.pendingPages) == 0:
                 return
             page = self.pendingPages.pop()
-            threading.Thread(target=self.stalkStories, args=(page,)).start()
-            threading.Thread(target=self.stalkPosts, args=(page,)).start()
+            if (config["onlyStories"] and config["onlyPosts"]):
+                logger.error("Can't have onlyStroies and onlyPosts as true - exiting")
+                return
+            elif (config["onlyPosts"]):
+                threading.Thread(target=self.stalkPosts, args=(page,)).start()
+            elif (config["onlyStories"]):
+                threading.Thread(target=self.stalkStories, args=(page,)).start()
+            else:
+                threading.Thread(target=self.stalkStories, args=(page,)).start()
+                threading.Thread(target=self.stalkPosts, args=(page,)).start()
 
     def getAlivePages(self):
         return self.alivePages

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ username = config['instance']['username']
 password = config['instance']['password']
 account = InstagramAPI(username, password)
 account.login()
+
 if account.LastJson['status'] == 'fail':
     print('Cannot login, {}'.format(account.LastJson['message']))
 else:

--- a/main.py
+++ b/main.py
@@ -11,6 +11,9 @@ account.login()
 if account.LastJson['status'] == 'fail':
     print('Cannot login, {}'.format(account.LastJson['message']))
 else:
-    
+    obj = Stalker(account)
+    # obj.addPage("")
+    obj.loadAllPages()
+    obj.startStalking()
     with open('session.pkl', 'wb') as target:
         pickle.dump(account, target)


### PR DESCRIPTION
* Can notify on posts now too
* Changed rate of checks to every 20 seconds (official maximum in Instagram API, although that's not exactly what we are using, it's still a good idea to decrease the rate of checks).
* Ability to only stalk stories or only stalk posts. This can be moved to being a command line argument if you'd rather, this was simpler.
* Added try/except for network call to instagram. Currently still exiting the thread, but could be changed to loop until success. I had the call have a json exception in the python instagram API module before so I know it can break.